### PR TITLE
feat(net8): upgrade to .net8

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['7.0']
+        dotnet-version: ['8.0']
 
     steps:
       - name: Set up JDK 17

--- a/.github/workflows/unit.tests-formatting.yml
+++ b/.github/workflows/unit.tests-formatting.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['7.0']
+        dotnet-version: ['8.0']
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For **installation** details and further information, please refer to the chart 
 
 ## How to build and run
 
-Install the [.NET 7.0 SDK](https://www.microsoft.com/net/download).
+Install the [.NET 8.0 SDK](https://www.microsoft.com/net/download).
 
 Run the following command from the CLI:
 

--- a/docker/Dockerfile-dim-migrations
+++ b/docker/Dockerfile-dim-migrations
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE /
 COPY /src/database /src/database

--- a/docker/Dockerfile-dim-processes-worker
+++ b/docker/Dockerfile-dim-processes-worker
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/runtime:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE /
 COPY src/ src/

--- a/docker/Dockerfile-dim-service
+++ b/docker/Dockerfile-dim-service
@@ -17,9 +17,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ###############################################################
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine AS base
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine AS base
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine-amd64 AS publish
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine-amd64 AS publish
 WORKDIR /
 COPY LICENSE /
 COPY src/ src/

--- a/src/clients/Dim.Clients/Dim.Clients.csproj
+++ b/src/clients/Dim.Clients/Dim.Clients.csproj
@@ -20,7 +20,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Dim.Clients</RootNamespace>
@@ -29,15 +29,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="1.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="1.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.HttpClientExtensions" Version="2.0.0" />
     </ItemGroup>
 
 </Project>

--- a/src/database/Dim.DbAccess/Dim.DbAccess.csproj
+++ b/src/database/Dim.DbAccess/Dim.DbAccess.csproj
@@ -20,7 +20,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Dim.DbAccess</RootNamespace>
@@ -28,9 +28,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.12" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="1.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.3" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DependencyInjection" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/database/Dim.Entities/Dim.Entities.csproj
+++ b/src/database/Dim.Entities/Dim.Entities.csproj
@@ -1,4 +1,4 @@
-<!--
+  <!--
 - Copyright (c) 2024 BMW Group AG
 -
 - See the NOTICE file(s) distributed with this work for additional
@@ -20,19 +20,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>Dim.Entities</RootNamespace>
         <AssemblyName>Dim.Entities</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.10">
+      <PackageReference Include="EFCore.NamingConventions" Version="8.0.3" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         <PrivateAssets>all</PrivateAssets>
       </PackageReference>
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="1.3.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DBAccess" Version="2.0.0" />
     </ItemGroup>
 </Project>

--- a/src/database/Dim.Migrations/Dim.Migrations.csproj
+++ b/src/database/Dim.Migrations/Dim.Migrations.csproj
@@ -22,7 +22,7 @@
     <PropertyGroup>
         <RootNamespace>Dim.Migrations</RootNamespace>
         <AssemblyName>Dim.Migrations</AssemblyName>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
@@ -35,18 +35,18 @@
     </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.10">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="1.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="1.3.0" />
-    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="1.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Models" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
+    <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Seeding" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/processes/DimProcess.Executor/DimProcess.Executor.csproj
+++ b/src/processes/DimProcess.Executor/DimProcess.Executor.csproj
@@ -22,14 +22,14 @@
     <PropertyGroup>
         <RootNamespace>DimProcess.Executor</RootNamespace>
         <AssemblyName>DimProcess.Executor</AssemblyName>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/processes/DimProcess.Executor/DimProcessTypeExecutor.cs
+++ b/src/processes/DimProcess.Executor/DimProcessTypeExecutor.cs
@@ -127,9 +127,9 @@ public class DimProcessTypeExecutor : IProcessTypeExecutor
                     .ConfigureAwait(false),
                 ProcessStepTypeId.CREATE_COMPANY_IDENTITY => await _dimProcessHandler.CreateCompanyIdentity(_tenantId, _tenantName, cancellationToken)
                     .ConfigureAwait(false),
-                ProcessStepTypeId.CREATE_STATUS_LIST => await _dimProcessHandler.CreateStatusList(_tenantId, cancellationToken)
-                    .ConfigureAwait(false),
                 ProcessStepTypeId.ASSIGN_COMPANY_APPLICATION => await _dimProcessHandler.AssignCompanyApplication(_tenantId, cancellationToken)
+                    .ConfigureAwait(false),
+                ProcessStepTypeId.CREATE_STATUS_LIST => await _dimProcessHandler.CreateStatusList(_tenantId, cancellationToken)
                     .ConfigureAwait(false),
                 ProcessStepTypeId.SEND_CALLBACK => await _dimProcessHandler.SendCallback(_tenantId, cancellationToken)
                     .ConfigureAwait(false),

--- a/src/processes/DimProcess.Library/Callback/DependencyInjection/CallbackSettings.cs
+++ b/src/processes/DimProcess.Library/Callback/DependencyInjection/CallbackSettings.cs
@@ -23,5 +23,5 @@ namespace DimProcess.Library.Callback.DependencyInjection;
 
 public class CallbackSettings : KeyVaultAuthSettings
 {
-    public string BaseAddress { get; set; }
+    public string BaseAddress { get; set; } = null!;
 }

--- a/src/processes/DimProcess.Library/DimProcess.Library.csproj
+++ b/src/processes/DimProcess.Library/DimProcess.Library.csproj
@@ -22,16 +22,16 @@
     <PropertyGroup>
         <RootNamespace>DimProcess.Library</RootNamespace>
         <AssemblyName>DimProcess.Library</AssemblyName>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>415ef31b-ed90-4c9e-9e5f-5f3e673d4f91</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Token" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/processes/Processes.Library/Processes.Library.csproj
+++ b/src/processes/Processes.Library/Processes.Library.csproj
@@ -22,7 +22,7 @@
     <PropertyGroup>
         <AssemblyName>Dim.Processes.Library</AssemblyName>
         <RootNamespace>Dim.Processes.Library</RootNamespace>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <UserSecretsId>76a1cf69-39e1-43a7-b6a7-fef83be5359f</UserSecretsId>
@@ -34,7 +34,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Flurl.Http.Signed" Version="3.2.4" />
+      <PackageReference Include="Flurl.Http.Signed" Version="4.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
+++ b/src/processes/Processes.Worker.Library/Processes.Worker.Library.csproj
@@ -22,18 +22,18 @@
     <PropertyGroup>
       <AssemblyName>Processes.Worker.Library</AssemblyName>
       <RootNamespace>Processes.Worker.Library</RootNamespace>
-      <TargetFramework>net7.0</TargetFramework>
+      <TargetFramework>net8.0</TargetFramework>
       <ImplicitUsings>enable</ImplicitUsings>
       <Nullable>enable</Nullable>
     </PropertyGroup>
   
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.4" />
-      <PackageReference Include="Microsoft.Extensions.Options" Version="7.0.1" />
-      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="7.0.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="1.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="1.3.0" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.1" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Async" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.DateTimeProvider" Version="2.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.ErrorHandling" Version="2.0.0" />
       <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>
 

--- a/src/processes/Processes.Worker/Processes.Worker.csproj
+++ b/src/processes/Processes.Worker/Processes.Worker.csproj
@@ -22,7 +22,7 @@
     <PropertyGroup>
         <AssemblyName>Processes.Worker</AssemblyName>
         <RootNamespace>Processes.Worker</RootNamespace>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <OutputType>Exe</OutputType>
@@ -39,8 +39,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
-      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="1.3.0" />
+      <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+      <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Logging" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/web/Dim.Web/Dim.Web.csproj
+++ b/src/web/Dim.Web/Dim.Web.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <InvariantGlobalization>true</InvariantGlobalization>
@@ -13,9 +13,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.10"/>
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3"/>
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0"/>
-        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="1.3.0"/>
+        <PackageReference Include="Org.Eclipse.TractusX.Portal.Backend.Framework.Web" Version="2.0.0"/>
         <PackageReference Include="System.Json" Version="4.7.1" />
     </ItemGroup>
 

--- a/tests/processes/DimProcess.Executor.Tests/DimProcess.Executor.Tests.csproj
+++ b/tests/processes/DimProcess.Executor.Tests/DimProcess.Executor.Tests.csproj
@@ -17,7 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/processes/DimProcess.Library.Tests/DimProcess.Library.Tests.csproj
+++ b/tests/processes/DimProcess.Library.Tests/DimProcess.Library.Tests.csproj
@@ -13,11 +13,11 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/processes/Processes.Library.Tests/Processes.Library.Tests.csproj
+++ b/tests/processes/Processes.Library.Tests/Processes.Library.Tests.csproj
@@ -32,11 +32,11 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/processes/Processes.Worker.Library.Tests/Processes.Worker.Library.Tests.csproj
+++ b/tests/processes/Processes.Worker.Library.Tests/Processes.Worker.Library.Tests.csproj
@@ -32,11 +32,11 @@
         <PackageReference Include="FluentAssertions" Version="6.12.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="xunit" Version="2.7.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
+        <PackageReference Include="coverlet.collector" Version="6.0.2">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/shared/Tests.Shared/Tests.Shared.csproj
+++ b/tests/shared/Tests.Shared/Tests.Shared.csproj
@@ -22,14 +22,14 @@
   <PropertyGroup>
     <AssemblyName>Dim.Tests.Shared</AssemblyName>
     <RootNamespace>Dim.Tests.Shared</RootNamespace>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Testcontainers" Version="3.7.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="3.7.0" />
+    <PackageReference Include="Testcontainers" Version="3.8.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="3.8.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

* upgrade nuget packages
* remove configureAwait from unit tests

## Why

Since .NET 7 is only supported until May 14, 2024 the portal services and jobs are upgraded to .NET 8 which is an LTS version

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
