### PR TITLE
chore: adjust get queries to filter for name

### DIFF
--- a/charts/dim/Chart.yaml
+++ b/charts/dim/Chart.yaml
@@ -20,8 +20,8 @@
 apiVersion: v2
 name: dim
 type: application
-version: 0.0.5
-appVersion: 0.0.5
+version: 0.0.6
+appVersion: 0.0.6
 description: Helm chart for DIM Middle Layer
 home: https://github.com/catenax-ng/dim-repo
 dependencies:

--- a/charts/dim/README.md
+++ b/charts/dim/README.md
@@ -27,7 +27,7 @@ To use the helm chart as a dependency:
 dependencies:
   - name: dim
     repository: https://phil91.github.io/dim-client
-    version: 0.0.5
+    version: 0.0.6
 ```
 
 ## Requirements

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,7 +19,7 @@
 
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.0.5</VersionPrefix>
+    <VersionPrefix>0.0.6</VersionPrefix>
     <VersionSuffix></VersionSuffix>
   </PropertyGroup>
 </Project>

--- a/src/clients/Dim.Clients/Api/Cf/CfClient.cs
+++ b/src/clients/Dim.Clients/Api/Cf/CfClient.cs
@@ -71,7 +71,7 @@ public class CfClient : ICfClient
 
     private static async Task<Guid> GetEnvironmentId(string tenantName, CancellationToken cancellationToken, HttpClient client)
     {
-        var environmentsResponse = await client.GetAsync("/v3/organizations", cancellationToken)
+        var environmentsResponse = await client.GetAsync($"/v3/organizations?names={tenantName}", cancellationToken)
             .CatchingIntoServiceExceptionFor("get-organizations", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE);
         var environments = await environmentsResponse.Content
             .ReadFromJsonAsync<GetEnvironmentsResponse>(JsonSerializerExtensions.Options, cancellationToken)
@@ -136,7 +136,7 @@ public class CfClient : ICfClient
     {
         var spaceName = $"{tenantName}-space";
         var client = await _basicAuthTokenService.GetBasicAuthorizedLegacyClient<CfClient>(_settings, cancellationToken).ConfigureAwait(false);
-        var result = await client.GetAsync("/v3/spaces", cancellationToken)
+        var result = await client.GetAsync($"/v3/spaces?names={spaceName}", cancellationToken)
             .CatchingIntoServiceExceptionFor("get-space", HttpAsyncResponseMessageExtension.RecoverOptions.ALLWAYS).ConfigureAwait(false);
         try
         {
@@ -180,8 +180,9 @@ public class CfClient : ICfClient
 
     private async Task<Guid> GetServiceInstances(string tenantName, Guid? spaceId, CancellationToken cancellationToken)
     {
+        var name = $"{tenantName}-dim-instance";
         var client = await _basicAuthTokenService.GetBasicAuthorizedLegacyClient<CfClient>(_settings, cancellationToken).ConfigureAwait(false);
-        var result = await client.GetAsync("/v3/service_instances", cancellationToken)
+        var result = await client.GetAsync($"/v3/service_instances?names={name}", cancellationToken)
             .CatchingIntoServiceExceptionFor("get-si", HttpAsyncResponseMessageExtension.RecoverOptions.INFRASTRUCTURE).ConfigureAwait(false);
         try
         {
@@ -193,7 +194,6 @@ public class CfClient : ICfClient
                 throw new ServiceException("Response must not be null");
             }
 
-            var name = $"{tenantName}-dim-instance";
             var resources = response.Resources.Where(x => x.Name == name && x.Type == "managed" && (spaceId == null || x.Relationships.Space.Data.Id == spaceId.Value) && x.LastOperation.State == "succeeded");
             if (resources.Count() != 1)
             {


### PR DESCRIPTION
## Description

Adjusted the get queries to filter for the respective name of the searched elements

## Why

The default limit for the get requests are 50 items. Since the tenant already has more than 50 entries, the queries needed to be adjusted.

## Issue

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have successfully tested my changes locally
- [x] I have added tests that prove my changes work
- [x] I have checked that new and existing tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added copyright and license headers, footers (for .md files) or files (for images)
